### PR TITLE
Fix Ridge minimum constant and add tests

### DIFF
--- a/src/single.rs
+++ b/src/single.rs
@@ -374,7 +374,9 @@ mod ridge_tests {
     fn f_matches_minimum() {
         let minimizer = F::minimizer(F::LOW_D);
 
-        assert_eq!(F::f(minimizer), F::MINIMUM);
+        let difference = (F::f(minimizer) - F::MINIMUM).abs();
+
+        assert!(difference <= f64::EPSILON);
     }
 
     #[test]

--- a/src/single.rs
+++ b/src/single.rs
@@ -334,7 +334,7 @@ impl Bounded for Ridge {
 }
 
 impl SingleObjective for Ridge {
-    /// The global minimum is constant and zero
+    /// The global minimum equals the first coordinate of the minimizer.
     const MINIMUM: f64 = -5.0;
 
     /// Function for evaluating
@@ -368,6 +368,21 @@ mod ridge_tests {
     #[test]
     fn high_d() {
         F::check_minimizer(F::HIGH_D);
+    }
+
+    #[test]
+    fn f_matches_minimum() {
+        let minimizer = F::minimizer(F::LOW_D);
+
+        assert_eq!(F::f(minimizer), F::MINIMUM);
+    }
+
+    #[test]
+    fn minimizer_respects_dimension() {
+        let dimension = 5;
+        let minimizer = F::minimizer(dimension);
+
+        assert_eq!(minimizer.len(), dimension);
     }
 }
 


### PR DESCRIPTION
## Summary
- clarify the Ridge function minimum constant to match its minimizer
- add regression tests verifying Ridge minimizer output and length

## Testing
- cargo test ridge_tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922174495a083259ffea524f4072138)